### PR TITLE
feat: declare python-api as an extra

### DIFF
--- a/mlflow_provider/hooks/deployment.py
+++ b/mlflow_provider/hooks/deployment.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, TYPE_CHECKING
 
-from mlflow.deployments import BaseDeploymentClient, get_deploy_client
+try:
+    from mlflow.deployments import get_deploy_client
+except ModuleNotFoundError:
+    import warnings
+    warnings.warn("Could not import mlflow.deployments. Did you install `python-api` extra?")
+
+if TYPE_CHECKING:
+    from mlflow.deployments import BaseDeploymentClient
 
 from mlflow_provider.hooks.base import MLflowBaseHook
 
@@ -56,7 +63,6 @@ class MLflowDeploymentHook(MLflowBaseHook):
         """
         Returns MLflow deployment Client.
         """
-
         target_conn_type = self.get_connection(self.target_conn_id).conn_type
 
         # TODO see if other connection types for AWS need to be handled

--- a/mlflow_provider/hooks/pyfunc.py
+++ b/mlflow_provider/hooks/pyfunc.py
@@ -1,4 +1,13 @@
-from mlflow import pyfunc
+from __future__ import annotations
+
+
+try:
+    from mlflow import pyfunc
+except ModuleNotFoundError:
+    import warnings
+    warnings.warn("Could not import mlflow. Did you install `python-api` extra?")
+
+
 
 from mlflow_provider.hooks.base import MLflowBaseHook
 

--- a/mlflow_provider/operators/pyfunc.py
+++ b/mlflow_provider/operators/pyfunc.py
@@ -1,17 +1,20 @@
 from __future__ import annotations
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Dict, Union, List, Sequence
+from typing import Any, Dict, Union, List, Sequence, TYPE_CHECKING
 
-from numpy import ndarray
-from pandas.core.frame import DataFrame
-from pandas.core.series import Series
 from airflow.exceptions import AirflowException
 from airflow.operators.python import _BasePythonVirtualenvOperator
 from airflow.utils import python_virtualenv
-from scipy.sparse import csc_matrix, csr_matrix
 
 from mlflow_provider.hooks.pyfunc import MLflowPyfuncHook
+
+if TYPE_CHECKING:
+    from numpy import ndarray
+    from pandas.core.frame import DataFrame
+    from pandas.core.series import Series
+    from scipy.sparse import csc_matrix, csr_matrix
+
 
 
 def _model_load_and_predict(

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,10 +34,11 @@ packages = find:
 include_package_data = true
 install_requires =
     apache-airflow>=2.2.0
-    mlflow>=2.0
 zip_safe = false
 
 [options.extras_require]
+python-api =
+    mlflow>=2.0
 dev =
     mypy>=0.800
     pytest


### PR DESCRIPTION
The operators under deployments and pyfunc are only available if python-api extra is installed. This makes it possible to use registry (MLFlow REST API) without mlflow python package.

Closes #27 